### PR TITLE
Fix gcc error: invalid use of incomplete type

### DIFF
--- a/include/geo/vector/vec2.h
+++ b/include/geo/vector/vec2.h
@@ -42,8 +42,8 @@ struct vec2 {
 	template <typename U = T, typename = IsFloatingPoint<U>>
 	static vec2<T> normalize(const vec2& vec);
 	static vec2<T> abs(const vec2<T>& vec);
-	static vec2<T> (min)(const vec2& lhs, const vec2& rhs);
-	static vec2<T> (max)(const vec2& lhs, const vec2& rhs);
+	static vec2<T> min(const vec2& lhs, const vec2& rhs);
+	static vec2<T> max(const vec2& lhs, const vec2& rhs);
 };
 
 template <typename T>

--- a/include/geo/vector/vec2.inl
+++ b/include/geo/vector/vec2.inl
@@ -88,7 +88,7 @@ inline vec2<T> vec2<T>::abs(const vec2<T>& vec)
 }
 
 template <typename T>
-inline vec2<T> (vec2<T>::min)(const vec2<T>& lhs, const vec2<T>& rhs)
+inline vec2<T> vec2<T>::min(const vec2<T>& lhs, const vec2<T>& rhs)
 {
 	return vec2f(
 		(geometry::min)(lhs.x, rhs.x),
@@ -97,7 +97,7 @@ inline vec2<T> (vec2<T>::min)(const vec2<T>& lhs, const vec2<T>& rhs)
 }
 
 template <typename T>
-inline vec2<T>(vec2<T>::max)(const vec2<T>& lhs, const vec2<T>& rhs)
+inline vec2<T> vec2<T>::max(const vec2<T>& lhs, const vec2<T>& rhs)
 {
 	return vec2f(
 		(geometry::max)(lhs.x, rhs.x),


### PR DESCRIPTION
GCC doesn't seem to like the use of parenthesis around the min and max functions. Removing them resolves the errors. Fixes issue #1.